### PR TITLE
Allow to use with latest eslint-config-standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "main": "index.js",
   "peerDependencies": {
     "eslint": ">=6.0.1",
-    "eslint-config-standard": "^13.0.1",
+    "eslint-config-standard": ">=14.1.0",
     "eslint-plugin-import": ">=2.18.0",
     "eslint-plugin-node": ">=9.1.0",
     "eslint-plugin-promise": ">=4.2.1",


### PR DESCRIPTION
Allows current and future versions of `eslint-config-standard` to be used as peer dependency.

**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
Relax the peer dependency requirement for `eslint-config-standard` to `>=14.1.0`.

**Which issue (if any) does this pull request address?**
Fixes #29

**Is there anything you'd like reviewers to focus on?**
