### PR TITLE
Remove unused eslint-plugin-standard peerDep

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [travis-image]: https://img.shields.io/travis/standard/eslint-config-semistandard.svg?style=flat-square
 [travis-url]: https://travis-ci.org/standard/eslint-config-semistandard
 
-eslint sharable config for semistandard – like [eslint-config-standard](https://github.com/feross/eslint-config-standard), but with semicolons
+eslint sharable config for semistandard – like [eslint-config-standard](https://github.com/standard/eslint-config-standard), but with semicolons
 
 ## Install
 
@@ -19,17 +19,17 @@ npx install-peerdeps --dev eslint-config-semistandard
 ```
 or the classic way:
 ```
-npm install --save-dev eslint-plugin-promise eslint-plugin-standard eslint-plugin-node eslint-plugin-import
+npm install --save-dev eslint-plugin-promise eslint-plugin-node eslint-plugin-import
 npm install --save-dev eslint-config-standard
 npm install --save-dev eslint-config-semistandard
-# note that eslint-plugin-promise, eslint-plugin-standard, eslint-plugin-node, eslint-plugin-import & eslint-config-standard are required peer dependencies
+# note that eslint-plugin-promise, eslint-plugin-node, eslint-plugin-import & eslint-config-standard are required peer dependencies
 ```
 
 ## Usage
 
 Read up on how to use [sharable configs](http://eslint.org/docs/developer-guide/shareable-configs) at the eslint website.
 
-For more details see [eslint-config-standard](https://github.com/feross/eslint-config-standard)
+For more details see [eslint-config-standard](https://github.com/standard/eslint-config-standard)
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,47 +1,46 @@
 {
   "name": "eslint-config-semistandard",
-  "description": "eslint sharable config for semistandard",
+  "description": "JavaScript Semistandard Style - ESLint Shareable Config",
   "version": "15.0.1",
   "author": "Dan Flettre <flettre@gmail.com>",
   "bugs": {
     "url": "https://github.com/standard/eslint-config-semistandard/issues"
   },
   "devDependencies": {
-    "eslint": "^6.0.1",
-    "eslint-config-standard": "^14.0.0",
-    "eslint-plugin-import": "^2.18.0",
-    "eslint-plugin-node": "^10.0.0",
+    "eslint": "^7.12.1",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.0",
     "tap-spec": "^5.0.0",
-    "tape": "^5.0.0"
+    "tape": "^5.0.1"
   },
   "homepage": "https://github.com/standard/eslint-config-semistandard",
   "keywords": [
-    "semistandard",
-    "style checker",
-    "code style",
+    "JavaScript Semistandard Style",
+    "check",
+    "checker",
+    "code",
     "code checker",
     "code linter",
-    "style linter",
-    "simple",
-    "policy",
-    "style",
-    "code",
-    "lint",
-    "eslint",
-    "jshint",
-    "jscs",
-    "hint",
-    "enforce",
-    "check",
-    "verify",
-    "quality",
-    "checker",
     "code standards",
-    "JavaScript Semistandard Style",
+    "code style",
+    "enforce",
+    "eslint",
+    "eslintconfig",
+    "hint",
+    "jscs",
+    "jshint",
+    "lint",
+    "policy",
+    "quality",
+    "simple",
+    "semistandard",
     "semistandard style",
-    "eslintconfig"
+    "style",
+    "style checker",
+    "style linter",
+    "verify"
   ],
   "license": "ISC",
   "main": "index.js",
@@ -49,19 +48,18 @@
     ".eslintrc.js"
   ],
   "peerDependencies": {
-    "eslint": ">=6.0.1",
-    "eslint-config-standard": ">=14.1.0",
-    "eslint-plugin-import": ">=2.18.0",
-    "eslint-plugin-node": ">=9.1.0",
-    "eslint-plugin-promise": ">=4.2.1",
-    "eslint-plugin-standard": ">=4.0.0"
+    "eslint": "^7.12.1",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^4.2.1"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/standard/eslint-config-semistandard.git"
   },
   "scripts": {
-    "test": "tape test/*.js | tap-spec",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "npm run lint && tape test/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "npm run lint && tape test/*.js"
+    "test": "tape test/*.js | tap-spec"
   }
 }


### PR DESCRIPTION
This PR does the following:
1. Removes the outdated and unused eslint-plugin-standard peerDependency
2. Makes peerDeps use ^ operator instead of >= as has already been done for other standard repos - requires bumping peerDeps more often but prevents upstream breaking changes from affecting users
2. Syncs the package.json metadata fields with their standard/eslint-config-standard equivalents