### PR TITLE
Upgrade dev dependencies and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/standard/eslint-config-semistandard/issues"
   },
   "devDependencies": {
-    "eslint": "^7.28.0",
-    "eslint-config-standard": "^16.0.3",
-    "eslint-plugin-import": "^2.23.4",
+    "eslint": "^8.13.0",
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0",
+    "eslint-plugin-promise": "^6.0.0",
     "tap-spec": "^5.0.0",
-    "tape": "^5.0.0"
+    "tape": "^5.5.3"
   },
   "homepage": "https://github.com/standard/eslint-config-semistandard",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint": "^8.13.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^15.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.5.3"
@@ -53,7 +53,7 @@
     "eslint": ">=7.12.1",
     "eslint-config-standard": ">=16.0.3",
     "eslint-plugin-import": ">=2.22.1",
-    "eslint-plugin-node": ">=11.1.0",
+    "eslint-plugin-n": ">=15.0.0",
     "eslint-plugin-promise": ">=4.2.1"
   },
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const { CLIEngine } = require('eslint');
+const { ESLint } = require('eslint');
 const test = require('tape');
 
-const configFile = require.resolve('../eslintrc.json');
-const linter = new CLIEngine({ configFile });
+const overrideConfigFile = require.resolve('../eslintrc.json');
+const linter = new ESLint({ overrideConfigFile });
 
-test('api: lintText', t => {
+test('api: lintText', async t => {
   t.plan(1);
-  const result = linter.executeOnText("console.log('hi there')\n\n");
-  t.equals(result.results[0].messages[0].message, 'Missing semicolon.');
+  const [result] = await linter.lintText("console.log('hi there')\n\n");
+  t.equal(result.messages[0].message, 'Missing semicolon.');
 });


### PR DESCRIPTION
Hi!

I was debugging something earlier and did the work to upgrade the dev dependencies and the test while at it.

I used the tests from eslint-config-standard as inspiration: https://github.com/standard/eslint-config-standard/blob/master/test/validate-config.js but I kept the existing code style and structure as my goal was to just make sure it works.

I decided to open this pull request with the changes in case it's helpful 🙂

The upgrade will break on Node 10.

Node 10 has been EOL since end of April 2021.
Node 12 EOL is end of April 2022, so very soon. https://nodejs.org/en/about/releases/

eslint-config-standard uses the `lts/*` setup-node action configuration: https://github.com/standard/eslint-config-standard/blob/master/.github/workflows/ci.yml#L15-L18 which should probably put into use in this repository as well. However, that is out of scope for this pull request as such I think.